### PR TITLE
Make flask app config file optional

### DIFF
--- a/servicex_codegen/__init__.py
+++ b/servicex_codegen/__init__.py
@@ -56,10 +56,10 @@ def create_app(test_config=None, provided_translator=None):
     except OSError:
         pass
 
-    if not test_config:
-        app.config.from_envvar('APP_CONFIG_FILE')
-    else:
+    if test_config:
         app.config.from_mapping(test_config)
+    elif 'APP_CONFIG_FILE' in os.environ:
+        app.config.from_envvar('APP_CONFIG_FILE')
 
     with app.app_context():
         translator = provided_translator


### PR DESCRIPTION
No need to setup environment vars and such if a code generator doesn't require any config. Make the config optional