### PR TITLE
Allow for separate code gen app config

### DIFF
--- a/servicex_codegen/__init__.py
+++ b/servicex_codegen/__init__.py
@@ -57,8 +57,11 @@ def create_app(test_config=None, provided_translator=None):
 
     if test_config:
         app.config.from_mapping(test_config)
-    elif 'APP_CONFIG_FILE' in os.environ:
-        app.config.from_envvar('APP_CONFIG_FILE')
+    else:
+        if 'APP_CONFIG_FILE' in os.environ:
+            app.config.from_envvar('APP_CONFIG_FILE')
+        if 'CODEGEN_CONFIG_FILE' in os.environ:
+            app.config.from_envvar('CODEGEN_CONFIG_FILE')
 
     with app.app_context():
         translator = provided_translator

--- a/servicex_codegen/post_operation.py
+++ b/servicex_codegen/post_operation.py
@@ -92,6 +92,8 @@ class GeneratedCode(Resource):
                 zip_data = self.stream_generated_code(generated_code_result)
                 # code gen transformer returns the default transformer image mentioned in the config file
                 transformer_image = current_app.config.get("TRANSFORMER_SCIENCE_IMAGE")
+
+                print("------> Transformer_image = ",transformer_image)
                 # Send the response back to you-know-what.
 
                 # MultipartEncoder library takes multiple types of data fields and merge them into a multipart mime data type

--- a/servicex_codegen/post_operation.py
+++ b/servicex_codegen/post_operation.py
@@ -90,13 +90,12 @@ class GeneratedCode(Resource):
                     body["code"], cache_path=tempdir)
 
                 zip_data = self.stream_generated_code(generated_code_result)
-                # code gen transformer returns the default transformer image mentioned in the config file
+                # code gen transformer returns the default transformer image mentioned in
+                # the config file
                 transformer_image = current_app.config.get("TRANSFORMER_SCIENCE_IMAGE")
 
-                print("------> Transformer_image = ",transformer_image)
-                # Send the response back to you-know-what.
-
-                # MultipartEncoder library takes multiple types of data fields and merge them into a multipart mime data type
+                # MultipartEncoder library takes multiple types of data fields and merge
+                # them into a multipart mime data type
                 m = MultipartEncoder(
                     fields={'transformer_image': transformer_image,
                             'zip_data': zip_data}


### PR DESCRIPTION
# Problem
With the code generator providing the default transformer image, we need to read values from an app config file produced by the helm chart. The docker image overrides the environment var and provides its own app.conf.

# Approach
Read in the default app conf and then use a second env var to represent the config file associated with the code gen