### PR TITLE
Unpin urllib3 as needed to fix security issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ itsdangerous = "^2.1.2"
 Werkzeug = "^3.0.4"
 Jinja2 = "^3.1.2"
 requests-toolbelt = "^0.10.1"
-urllib3 = "1.26.18"
+urllib3 = "^1.26.19"
 
 [tool.poetry.group.test]
 optional = true


### PR DESCRIPTION
As this is a library, do not require a specific version of urllib3, but require at least 1.26.19 due to security alert on 1.26.18