### PR TITLE
Update minimum urllib3 version to something supported

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Install poetry
       uses: abatilo/actions-poetry@v2
       with:
-        poetry-version: 1.2.2
+        poetry-version: 2.1.1
     - name: Install dependencies
       run: |
         poetry install --no-root --with=test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ Flask-WTF = "^1.0.1"
 itsdangerous = "^2.1.2"
 Werkzeug = "^3.0.4"
 Jinja2 = "^3.1.2"
-requests-toolbelt = "^0.10.1"
-urllib3 = "^1.26.19"
+requests-toolbelt = "^1.0.0"
+urllib3 = "^2.5.0"
 
 [tool.poetry.group.test]
 optional = true


### PR DESCRIPTION
The urllib3 1.26.X series is no longer maintained and there is no real reason we should force downstream packages to use it (which is the effect of the ^ restriction syntax). Raise this so we will take urllib3 2.5.0 or higher.